### PR TITLE
Attach frida to the spawned pid instead of the name

### DIFF
--- a/fridahook.py
+++ b/fridahook.py
@@ -10,7 +10,7 @@ def main():
     pid = device.spawn('com.YoStarEN.Arknights')
     device.resume(pid)
     time.sleep(5)
-    session = device.attach("Arknights", realm='emulated')
+    session = device.attach(pid, realm='emulated')
     script = session.create_script("""
     var proc = Module.findBaseAddress("libil2cpp.so")
     console.log("Initiating!")


### PR DESCRIPTION
This may fix some cases where frida tries to attach to the wrong process
Kudos to @Sedurin for the idea.
